### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/motionclouds/mcClass.py
+++ b/motionclouds/mcClass.py
@@ -72,9 +72,9 @@ class motionCloud:
         self.sv=1/(self.rho*self.LifeTime)
         if self.show:
             if self.sv >(-2*np.sqrt(2)+4)/(self.N*self.dt):
-                print('LifeTime=%f must be greater than %f \n' %(self.LifeTime,((self.N*self.dt)/((-2*np.sqrt(2)+4)*self.rho))) )
+                print('LifeTime={0:f} must be greater than {1:f} \n'.format(self.LifeTime, ((self.N*self.dt)/((-2*np.sqrt(2)+4)*self.rho))) )
             else:
-                print('Correct parameters LifeTime = %f > %f \n' % (self.LifeTime,((self.N*self.dt)/((-2*np.sqrt(2)+4)*self.rho))) )
+                print('Correct parameters LifeTime = {0:f} > {1:f} \n'.format(self.LifeTime, ((self.N*self.dt)/((-2*np.sqrt(2)+4)*self.rho))) )
 
         Lx=np.concatenate((np.linspace(0,self.N/2-1,self.N/2),np.linspace(-self.N/2,-1,self.N/2)))
         x,y=np.meshgrid(Lx,Lx)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:JonathanVacher:projects?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:JonathanVacher:projects?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)